### PR TITLE
Fix mismatch between south and east cases

### DIFF
--- a/src/capps/scrabble/AIPlayer.java
+++ b/src/capps/scrabble/AIPlayer.java
@@ -200,7 +200,7 @@ public class AIPlayer {
 						}
 					}
 				}
-				for (int r1 = r; r1 < wLen ;r1++) {
+				for (int r1 = r; ;r1++) {
 					if (r1 >= ROWS || b[r1][c].getLetter() == EMPTY)
 						break; 
 					searchedS[r1][c] = true; 
@@ -267,7 +267,7 @@ public class AIPlayer {
 
 							String grabTiles = rack.hasTiles(substr); 
 
-							ScrabbleMove tryMove = new ScrabbleMove(r-j,c,cand.toString(),grabTiles,DIR.E); 
+							ScrabbleMove tryMove = new ScrabbleMove(r,c-j,cand.toString(),grabTiles,DIR.E); 
 							if (sb.isValidMove(tryMove)) {
 								int score = sb.computeScore(tryMove);
 								if (bestMoveSoFar == null || bestScoreSoFar < score) {


### PR DESCRIPTION
I discovered this bug after porting your code to GDScript for my game jam game A Bag Deal: https://jamiehello.itch.io/a-bag-deal

This change is a backport to Java. I have not run or tested this Java version, though the change seems straightforward to me.

The bug had caused Player 1 to play EEQUITES in the following screenshot: https://cdn.discordapp.com/attachments/218820487105478657/1127713889115717762/image.png
It happened before Player 2 played RIFLEMAN. EQUITES was already on the board. Player 1's rack was VOIOEII. The word list was CSW22 (279077 words). Note that the bonus placements and tile values are nonstandard.